### PR TITLE
Support DDC on MacOS via ddc-macos-rs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,8 @@ ddc-winapi = { version = "^0.2.0", optional = true }
 nvapi = { version = "^0.1.2", default-features = false, features = ["i2c"], optional = true }
 ddc-i2c = { version = "^0.2.1", optional = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+ddc-macos = { version = "^0.2.0", optional = true }
+
 [features]
-default = ["ddc-i2c", "ddc-winapi", "nvapi"]
+default = ["ddc-i2c", "ddc-winapi", "nvapi", "ddc-macos"]

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,11 @@ fn emit_feature(name: &str) {
 }
 
 fn main() {
-    if var("CARGO_CFG_UNIX").is_ok() {
+    if var("CARGO_CFG_TARGET_OS") == Ok("macos".into()) {
+        if feature_enabled("ddc-macos") {
+            emit_feature("has-ddc-macos");
+        }
+    } else if var("CARGO_CFG_UNIX").is_ok() {
         if feature_enabled("ddc-i2c") {
             emit_feature("has-ddc-i2c");
         }


### PR DESCRIPTION
I've implemented DDC traits on MacOS, and this PR brings MacOS compatibility into `ddc-hi`, so all three major platforms are supported: Windows, Linux and Mac.