### PR TITLE
feat: Use concrete error types (using thiserror)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ edid = "^0.3.0"
 mccs = "^0.1.0"
 mccs-caps = "^0.1.0"
 mccs-db = "^0.1.1"
-anyhow = "^1.0.42"
 log = "^0.4.1"
+thiserror = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ddc-i2c = { version = "^0.2.1", features = ["with-linux", "with-linux-enumerate"], optional = true }


### PR DESCRIPTION
`anyhow` is great for end-user applications but some libraries that use this crate might require more fine-grained control/inspection over the different errors that can occur.